### PR TITLE
FEAT: Implement Topic  Renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ pip install rattlesume
 ## Snippets
 
 To start, create a `content` directory with a subdirectory
-to organize a class of snippets. **The name of the
-subdirectory will be the same as the header in the final resume.**
+to organize a class of snippets.
 
 ```
  example/content/
@@ -65,8 +64,12 @@ The format of this value is still in flux.
 The `resume` section has arbitrary sub-key corresponding to the
 names of the subdirectories the snippets are located in.
 
-Each of these sub-keys take a list of values, which are ether file names
-or special values.
+Each of these directories takes two values, `name` and `contents`.
+`contents` is a list of values, which are ether file names or special values.
+`header` changes the default header from the sub-key to the given value.
+
+If all other keys are omitted the `contents` can be listed directly under the
+directory name.
 
 For example, the aforementioned 'FooBar.md' could be defined as follows:
 
@@ -78,6 +81,12 @@ resume:
   experience:
     - "---"
     - "FooBar.md"
+# OR
+  experience:
+    header: "Work Experience"
+    contents:
+      - "---"
+      - "FooBar.md"
 ```
 
 There is currently only one special value,

--- a/rattlesume/builder.py
+++ b/rattlesume/builder.py
@@ -66,7 +66,13 @@ def build_header(structure: dict) -> str:
 def build_body(structure: dict, base_path: Path):
     document = ""
     for category, snippets in structure.items():
-        document += f"\n\n# {category.strip().capitalize()}\n\n"
+        if not isinstance(snippets, list):
+            header = snippets["name"]
+            snippets = snippets["contents"]
+        else:
+            header = category.strip().capitalize()
+
+        document += f"\n\n# {header}\n\n"
         for snippet in snippets:
             match snippet:
                 case "---":


### PR DESCRIPTION
Adds two new keys under the topic headers. `snippets` which takes the place of the no-key behavior, and `name` which takes the exact string to use as the topic header.